### PR TITLE
Update oxpassport health checks

### DIFF
--- a/examples/kubernetes/minikube/oxpassport/oxpassport.yaml
+++ b/examples/kubernetes/minikube/oxpassport/oxpassport.yaml
@@ -56,13 +56,13 @@ spec:
             name: oxpassport-cm
         livenessProbe:
           httpGet:
-            path: /passport
+            path: /passport/token
             port: 8090
           initialDelaySeconds: 30
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /passport
+            path: /passport/token
             port: 8090
           initialDelaySeconds: 25
           periodSeconds: 25


### PR DESCRIPTION
### What does this PR do?
Update `oxpassport` liveliness and readiness probe's `URL`

### Description of work done
- Change the liveliness probe url from `/passport` to `/passport/token`
- Change the readiness probe url from `/passport` to `/passport/token`

### GH issue number
[issue #1 ](https://github.com/GluuFederation/community-edition-containers/issues/1)