### PR TITLE
Introduce dynamic container configuration

### DIFF
--- a/pygluu-compose/pygluu/compose/templates/docker-compose.yml
+++ b/pygluu-compose/pygluu/compose/templates/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - CONSUL_BIND_INTERFACE=eth0
       - CONSUL_CLIENT_INTERFACE=eth0
-    container_name: consul
+    container_name: ${CONSUL_NAME}
     restart: unless-stopped
     volumes:
       - ./volumes/consul:/consul/data
@@ -17,7 +17,7 @@ services:
     mem_limit: 512M
 
   vault:
-    container_name: vault
+    container_name: ${VAULT_NAME}
     image: vault:1.0.1
     command: vault server -config=/vault/config
     volumes:
@@ -31,7 +31,7 @@ services:
       - VAULT_REDIRECT_INTERFACE=eth0
       - VAULT_CLUSTER_INTERFACE=eth0
       - VAULT_ADDR=http://0.0.0.0:8200
-      - VAULT_LOCAL_CONFIG={"backend":{"consul":{"address":"consul:8500","path":"vault/"}},"listener":{"tcp":{"address":"0.0.0.0:8200","tls_disable":1}}}
+      - VAULT_LOCAL_CONFIG={"backend":{"consul":{"address":"${CONSUL_NAME}:8500","path":"vault/"}},"listener":{"tcp":{"address":"0.0.0.0:8200","tls_disable":1}}}
     restart: unless-stopped
     depends_on:
       - consul
@@ -39,8 +39,8 @@ services:
 
   registrator:
     image: gliderlabs/registrator:master
-    command: -internal -cleanup -resync 30 -retry-attempts 5 -retry-interval 10 -explicit consul://consul:8500
-    container_name: registrator
+    command: -internal -cleanup -resync 30 -retry-attempts 5 -retry-interval 10 -explicit consul://${CONSUL_NAME}:8500
+    container_name: ${REGISTRATOR_NAME}
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock
     restart: unless-stopped
@@ -51,12 +51,12 @@ services:
   nginx:
     image: gluufederation/nginx:4.2.3_01
     environment:
-      - GLUU_CONFIG_CONSUL_HOST=consul
-      - GLUU_SECRET_VAULT_HOST=vault
+      - GLUU_CONFIG_CONSUL_HOST=${CONSUL_NAME}
+      - GLUU_SECRET_VAULT_HOST=${VAULT_NAME}
     ports:
       - "80:80"
       - "443:443"
-    container_name: nginx
+    container_name: ${NGINX_NAME}
     restart: unless-stopped
     volumes:
       - ./vault_role_id.txt:/etc/certs/vault_role_id

--- a/pygluu-compose/pygluu/compose/templates/docker.env
+++ b/pygluu-compose/pygluu/compose/templates/docker.env
@@ -1,0 +1,8 @@
+CONSUL_NAME=consul
+LDAP_NAME=ldap
+NGINX_NAME=nginx
+OXAUTH_NAME=oxauth
+OXTRUST_NAME=oxtrust
+PERSISTANCE_NAME=persistence
+REGISTRATOR_NAME=registrator
+VAULT_NAME=vault

--- a/pygluu-compose/pygluu/compose/templates/job.persistence.yml
+++ b/pygluu-compose/pygluu/compose/templates/job.persistence.yml
@@ -4,11 +4,11 @@ services:
   persistence:
     image: gluufederation/persistence:4.2.3_03
     environment:
-      - GLUU_CONFIG_CONSUL_HOST=consul
-      - GLUU_SECRET_VAULT_HOST=vault
+      - GLUU_CONFIG_CONSUL_HOST=${CONSUL_NAME}
+      - GLUU_SECRET_VAULT_HOST=${VAULT_NAME}
       - GLUU_PERSISTENCE_TYPE=${PERSISTENCE_TYPE}
       - GLUU_PERSISTENCE_LDAP_MAPPING=${PERSISTENCE_LDAP_MAPPING}
-      - GLUU_LDAP_URL=ldap:1636
+      - GLUU_LDAP_URL=${LDAP_NAME}:1636
       - GLUU_COUCHBASE_URL=${COUCHBASE_URL}
       - GLUU_COUCHBASE_USER=${COUCHBASE_USER}
       - GLUU_COUCHBASE_SUPERUSER=${COUCHBASE_SUPERUSER}
@@ -34,7 +34,7 @@ services:
       - GLUU_JACKRABBIT_ADMIN_PASSWORD_FILE=/etc/gluu/conf/jackrabbit_admin_password
     extra_hosts:
       - "${DOMAIN}:${HOST_IP}"
-    container_name: persistence
+    container_name: ${PERSISTANCE_NAME}
     volumes:
       - ./vault_role_id.txt:/etc/certs/vault_role_id
       - ./vault_secret_id.txt:/etc/certs/vault_secret_id

--- a/pygluu-compose/pygluu/compose/templates/svc.ldap.yml
+++ b/pygluu-compose/pygluu/compose/templates/svc.ldap.yml
@@ -5,16 +5,16 @@ services:
   ldap:
     image: gluufederation/opendj:4.2.3_02
     environment:
-      - GLUU_CONFIG_CONSUL_HOST=consul
-      - GLUU_SECRET_VAULT_HOST=vault
+      - GLUU_CONFIG_CONSUL_HOST=${CONSUL_NAME}
+      - GLUU_SECRET_VAULT_HOST=${VAULT_NAME}
       # the value must match service name `ldap` because other containers
       # use this value as LDAP hostname
-      - GLUU_CERT_ALT_NAME=ldap
-      - GLUU_LDAP_ADVERTISE_ADDR=ldap
+      - GLUU_CERT_ALT_NAME=${LDAP_NAME}
+      - GLUU_LDAP_ADVERTISE_ADDR=${LDAP_NAME}
       - GLUU_PERSISTENCE_TYPE=${PERSISTENCE_TYPE}
       - GLUU_PERSISTENCE_LDAP_MAPPING=${PERSISTENCE_LDAP_MAPPING}
-    container_name: ldap
-    hostname: ldap
+    container_name: ${LDAP_NAME}
+    hostname: ${LDAP_NAME}
     volumes:
       - ./volumes/opendj/config:/opt/opendj/config
       - ./volumes/opendj/ldif:/opt/opendj/ldif

--- a/pygluu-compose/pygluu/compose/templates/svc.oxauth.yml
+++ b/pygluu-compose/pygluu/compose/templates/svc.oxauth.yml
@@ -5,11 +5,11 @@ services:
   oxauth:
     image: gluufederation/oxauth:4.2.3_07
     environment:
-      - GLUU_CONFIG_CONSUL_HOST=consul
-      - GLUU_SECRET_VAULT_HOST=vault
+      - GLUU_CONFIG_CONSUL_HOST=${CONSUL_NAME}
+      - GLUU_SECRET_VAULT_HOST=${VAULT_NAME}
       - GLUU_PERSISTENCE_TYPE=${PERSISTENCE_TYPE}
       - GLUU_PERSISTENCE_LDAP_MAPPING=${PERSISTENCE_LDAP_MAPPING}
-      - GLUU_LDAP_URL=ldap:1636
+      - GLUU_LDAP_URL=${LDAP_NAME}:1636
       - GLUU_COUCHBASE_URL=${COUCHBASE_URL}
       - GLUU_COUCHBASE_USER=${COUCHBASE_USER}
       - GLUU_COUCHBASE_BUCKET_PREFIX=${COUCHBASE_BUCKET_PREFIX}
@@ -19,7 +19,7 @@ services:
       - GLUU_JACKRABBIT_ADMIN_PASSWORD_FILE=/etc/gluu/conf/jackrabbit_admin_password
     extra_hosts:
       - "${DOMAIN}:${HOST_IP}"
-    container_name: oxauth
+    container_name: ${OXAUTH_NAME}
     volumes:
       - ./vault_role_id.txt:/etc/certs/vault_role_id
       - ./vault_secret_id.txt:/etc/certs/vault_secret_id

--- a/pygluu-compose/pygluu/compose/templates/svc.oxtrust.yml
+++ b/pygluu-compose/pygluu/compose/templates/svc.oxtrust.yml
@@ -5,12 +5,12 @@ services:
   oxtrust:
     image: gluufederation/oxtrust:4.2.3_04
     environment:
-      - GLUU_CONFIG_CONSUL_HOST=consul
-      - GLUU_SECRET_VAULT_HOST=vault
-      - GLUU_OXAUTH_BACKEND=oxauth:8080
+      - GLUU_CONFIG_CONSUL_HOST=${CONSUL_NAME}
+      - GLUU_SECRET_VAULT_HOST=${VAULT_NAME}
+      - GLUU_OXAUTH_BACKEND=${OXAUTH_NAME}:8080
       - GLUU_PERSISTENCE_TYPE=${PERSISTENCE_TYPE}
       - GLUU_PERSISTENCE_LDAP_MAPPING=${PERSISTENCE_LDAP_MAPPING}
-      - GLUU_LDAP_URL=ldap:1636
+      - GLUU_LDAP_URL=${LDAP_NAME}:1636
       - GLUU_COUCHBASE_URL=${COUCHBASE_URL}
       - GLUU_COUCHBASE_USER=${COUCHBASE_USER}
       - GLUU_COUCHBASE_BUCKET_PREFIX=${COUCHBASE_BUCKET_PREFIX}
@@ -20,7 +20,7 @@ services:
       - GLUU_JACKRABBIT_ADMIN_PASSWORD_FILE=/etc/gluu/conf/jackrabbit_admin_password
     extra_hosts:
       - "${DOMAIN}:${HOST_IP}"
-    container_name: oxtrust
+    container_name: ${OXTRUST_NAME}
     volumes:
       - ./vault_role_id.txt:/etc/certs/vault_role_id
       - ./vault_secret_id.txt:/etc/certs/vault_secret_id


### PR DESCRIPTION
Hey there! I was about to set up Gluu v4.2 and required some changes to match my setup, which I would like to share with you. I'd be happy if you could utilize and integrate those in the main project, because it would probably also help other users. The code provided does not have any impact on a standard installation, but it makes the setup more flexible and replaces a few hardcoded parts of the existing codebase. 

## Usecases

The changes provided aim to match two usecases:
* Setup behind reverse proxy (same host)
* Changing container names to something more descriptive

### Reverse Proxy

Gluu itself is hardcoded to occupy the ports 80 and 443. As I wanted to setup Gluu behind an already running proxy using 80 and 443, I made the port-check more dynamic by querying exposed ports of the nginx container instead of using the hardcoded array `[80,443]`. If the Gluu ports are changed manually or port forwarding is disabled completely (as in my case), the setup script will not fail and continue the installation, as it doesn't matter that the default ports are already in use.

### Dynamic container names

I personally dislike the hardcoded container names, because a container simply named `nginx` or `ldap` isn't really descriptive. Unfortunately, the container hostnames are also used inside the code to execute specific tasks and also act as hostnames for container interaction.

I've extended the `ContainerHelper` contructor to fetch the real container name, e.g. `gluu_web` by the given compose service name (`nginx`). Furthermore, I've replaced hostnames in the compose templates with variables and added the ability to load variables from a file named `docker.env` (mainly because `.env` would be hidden and is on the gitignore list). By modifying the names in `docker.env`, container names can be changed to something more descriptive by the user, and all host-references are updated.

#### Downsides

Since I was just getting started with Gluu, I am only using the required services. All changes I've added in this PR are tested using the following services:
* consul
* ldap
* nginx
* oxauth
* oxtrust
* persistence
* registrator
* vault

To use other services with modified container names, further changes are required. Again, this is not an issue when using a standard setup process with unchanged container names but provides a starting point for more dynamic configuration.

### How to continue

Please let me know if you would like to include those changes in your project and if I can assist you any further.