### PR TITLE
 Introduce dynamic container configuration (Gluu 4.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![pygluu compose](https://github.com/GluuFederation/community-edition-containers/workflows/pygluu%20compose/badge.svg?branch=4.3)
 # Gluu Server Community Edition Containers
 
-[Gluu Server Community Edition Documentation](https://gluu.org/docs/gluu-server/4.2/)
+[Gluu Server Community Edition Documentation](https://gluu.org/docs/gluu-server/4.3/)
 
 ## Documentation
 

--- a/pygluu-compose/pygluu/compose/settings.py
+++ b/pygluu-compose/pygluu/compose/settings.py
@@ -15,6 +15,7 @@ DEFAULT_SETTINGS = {
     "STATE": "",
     "CITY": "",
     "SVC_LDAP": True,
+    "SVC_NGINX_PORTS": True,
     "SVC_OXAUTH": True,
     "SVC_OXTRUST": True,
     "SVC_OXPASSPORT": False,
@@ -60,6 +61,7 @@ DEFAULT_SETTINGS = {
 
 COMPOSE_MAPPINGS = {
     "SVC_LDAP": "svc.ldap.yml",
+    "SVC_NGINX_PORTS": "svc.nginx_ports.yml",
     "SVC_OXAUTH": "svc.oxauth.yml",
     "SVC_OXTRUST": "svc.oxtrust.yml",
     "SVC_OXPASSPORT": "svc.oxpassport.yml",

--- a/pygluu-compose/pygluu/compose/templates/docker-compose.yml
+++ b/pygluu-compose/pygluu/compose/templates/docker-compose.yml
@@ -53,9 +53,6 @@ services:
     environment:
       - GLUU_CONFIG_CONSUL_HOST=consul
       - GLUU_SECRET_VAULT_HOST=vault
-    ports:
-      - "80:80"
-      - "443:443"
     container_name: nginx
     restart: unless-stopped
     volumes:

--- a/pygluu-compose/pygluu/compose/templates/svc.nginx_ports.yml
+++ b/pygluu-compose/pygluu/compose/templates/svc.nginx_ports.yml
@@ -1,0 +1,8 @@
+# use v2.x API to allow `mem_limit` option
+version: "2.4"
+
+services:
+  nginx:
+    ports:
+      - "80:80"
+      - "443:443"


### PR DESCRIPTION
Hey there! As already mentioned in #31 I required some changes to match my setup, which I would like to share with you. I have now rebased them onto the 4.3 branch and expanded the container names to match all given services. The code provided does not have any impact on a standard installation, but it makes the setup more flexible and replaces a few hardcoded parts of the existing codebase.

## Usecases

The changes provided aim to match two usecases:
* Setup behind reverse proxy (same host)
* Changing container names to something more descriptive

### Reverse Proxy

Gluu itself is hardcoded to occupy the ports 80 and 443. As I wanted to setup Gluu behind an already running proxy using 80 and 443, I made the port-check more dynamic by querying exposed ports of the nginx container instead of using the hardcoded array `[80,443]`. If the Gluu ports are changed manually or port forwarding is disabled completely (as in my case), the setup script will not fail and continue the installation, as it doesn't matter that the default ports are already in use.

### Dynamic container names

I personally dislike the hardcoded container names, because a container simply named `nginx` or `ldap` isn't really descriptive. Unfortunately, the container hostnames are also used inside the code to execute specific tasks and also act as hostnames for container interaction.

I've extended the `ContainerHelper` contructor to fetch the real container name, e.g. `gluu_web` by the given compose service name (`nginx`). Furthermore, I've replaced hostnames in the compose templates with variables and added the ability to load variables from a file named `docker.env` (mainly because `.env` would be hidden and is on the gitignore list). By modifying the names in `docker.env`, container names can be changed to something more descriptive by the user, and all host-references are updated.

Also, I've changed the documentation link in the README from 4.2 to 4.3.