### PR TITLE
removed duplicate key restart

### DIFF
--- a/pygluu-compose/pygluu/compose/templates/docker-compose.yml
+++ b/pygluu-compose/pygluu/compose/templates/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 # use v2.x API to allow `mem_limit` option
 version: "2.4"
 
@@ -14,7 +15,6 @@ services:
     restart: unless-stopped
     volumes:
       - ./volumes/consul:/consul/data
-    restart: unless-stopped
     mem_limit: 512M
     ports:
       - "127.0.0.1:8500:8500"


### PR DESCRIPTION
Removed duplicate key `restart` in `docker-compose.yml` template. Should fix issue #50, but I couldn't test this due to missing build instructions.